### PR TITLE
use colon instead of hyphen to indicate the license

### DIFF
--- a/client/blocks/selector/i18n/en.yml
+++ b/client/blocks/selector/i18n/en.yml
@@ -1,4 +1,4 @@
 en-US:
-  author: by
-  license: license -
-  notfound: Ups... nothing found...
+  author: "by"
+  license: "license:"
+  notfound: "Ups! nothing found..."


### PR DESCRIPTION
I'm quoting the other entries for consistency and clarity (make it explicit that they're strings).
Also, changed "Ups..." to "Ups!", because it is an interjection and to prevent using two ellipses in the same sentence.
