### PR TITLE
Fix sorting of result codes in config

### DIFF
--- a/server/font/_lib/config.js
+++ b/server/font/_lib/config.js
@@ -115,7 +115,7 @@ function collectGlyphsInfo(clientConfig) {
   });
 
   // Sort result by original codes.
-  result.sort(function (a, b) { return a.from - b.from; });
+  result.sort(function (a, b) { return a.code - b.code; });
 
   return result;
 }


### PR DESCRIPTION
There is no `from` properties so they was replaced with `code`. This should fix [this](https://github.com/fontello/fontello/issues/283) issue.
