### PR TITLE
Add keyboard accessibility to toolbar and selector

### DIFF
--- a/client/blocks/selector/selector.jade
+++ b/client/blocks/selector/selector.jade
@@ -24,8 +24,8 @@
 
       .selector__glyphs-container
         ul.selector__glyphs-list.font-custom_icons(data-bind='visible: visibleCount(), foreach: glyphs')
-          li.selector__glyph(data-bind='visible: visible, attr: { "data-id": uid, title: tooltip }')
-            .selector__glyph-inner(data-bind="css: { checked: selected }, attr: { 'data-id': uid }", data-on-click='selector:glyph_toggle')
+          li.selector__glyph(role='checkbox', tabindex='0', data-bind='visible: visible, attr: { "data-id": uid, title: tooltip, "aria-checked": selected() ? "true" : "false" }', data-on-click='selector:glyph_toggle')
+            .selector__glyph-inner(data-bind="css: { checked: selected }, attr: { 'data-id': uid }")
               span.selector__glyph-image(data-bind='text: charRef')
             a.selector__glyph-delete.icon-edit(href='#', data-bind='attr: { "data-id": uid }', data-on-click='cmd:glyph_options')
 
@@ -59,8 +59,8 @@
 
       .selector__glyphs-container
         ul.selector__glyphs-list.font-fontello(data-bind='foreach: glyphs')
-          li.selector__glyph(data-bind='visible: visible, attr: { "data-id": uid, title: tooltip }')
-            .selector__glyph-inner(data-bind="css: { checked: selected, 'animate-spin': cssExt }, attr: { 'data-id': uid }", data-on-click='selector:glyph_toggle')
+          li.selector__glyph(role='checkbox', tabindex='0', data-bind='visible: visible, attr: { "data-id": uid, title: tooltip, "aria-checked": selected() ? "true" : "false" }, event: { keypress: selectOnEnter }', data-on-click='selector:glyph_toggle')
+            .selector__glyph-inner(data-bind="css: { checked: selected, 'animate-spin': cssExt }, attr: { 'data-id': uid }")
               span.selector__glyph-image(data-bind='text: charRef')
     // /ko
     // /ko

--- a/client/blocks/selector/selector.styl
+++ b/client/blocks/selector/selector.styl
@@ -124,6 +124,7 @@ a.selector__font-name
 
 .selector__glyph
   position relative
+  border-radius 30px
   float left
   margin 0 8px 8px 0
   width 48px 
@@ -187,9 +188,9 @@ a.selector__font-name
     border-radius 30px
     border 2px solid transparent
 
-  &:hover
-    background #333
-    color #fff
+.selector__glyph-inner:hover, .selector__glyph:focus .selector__glyph-inner
+  background #333
+  color #fff
 
 .selector__glyph.ui-selecting
 
@@ -201,18 +202,23 @@ a.selector__font-name
       color inherit
 
 .selector__glyph
-  .selector__glyph-inner.checked
-    background-color #fffdfd
-    &:before
-      border-color #d88
-    &:hover
-      background #666
-  &.ui-selecting .selector__glyph-inner.checked
-    background-color #eeffee
-    &before:
-      border-color #666
-    &:hover
-      color inherit
+  .selector__glyph-inner
+    &.checked
+      background-color #fffdfd
+      &:before
+        border-color #d88
+  &.ui-selecting
+    .selector__glyph-inner
+      &.checked
+        background-color #efe
+
+.selector__glyph .selector__glyph-inner.checked:hover, .selector__glyph:focus .selector__glyph-inner.checked
+  background #666
+
+.selector__glyph.ui-selecting .selector__glyph-inner.checkedbefore:border-color #666,
+.selector__glyph.ui-selecting .selector__glyph-inner.checked:hover
+  color inherit
+
 
 
 // Animation tweaks

--- a/client/blocks/toolbar/toolbar.jade
+++ b/client/blocks/toolbar/toolbar.jade
@@ -21,117 +21,119 @@
         i.icon-link
 
 
+    .btn-toolbar.pull-right
 
-
-    //- Show button, depending on mode
-    .btn-group.pull-right(data-bind='visible: !apiMode()')
-      //- Standard mode - `Download` button
-      button.btn.btn-danger.disabled(
-        data-on-click='build_font',
-        data-bind='css: {disabled: !selectedCount()}'): strong
-        i.icon-download(data-bind='visible: !building()')
-        i.icon-load.animate-spin(style='display:none', data-bind='visible: building()')
-        |  
-        = self.t('download')
-        |  (
-        span#selected-glyphs-count(data-bind='text: selectedCount()') 0
-        | )
-
-    .btn-group.pull-right(data-bind='visible: apiMode() && !apiUrl()', style='display:none')
-      //- API mode, without URL - `Save session` button
-      button.btn.btn-danger.disabled(
-        data-on-click='api.update',
-        data-bind='css: {disabled: !selectedCount()}'): strong
-        i.icon-download(data-bind='visible: !saving()')
-        i.icon-load.animate-spin(style='display:none', data-bind='visible: saving()')
-        |  
-        = self.t('save')
-        |  (
-        span#selected-glyphs-count(data-bind='text: selectedCount()') 0
-        | )
-      button.btn.btn-danger.disabled.dropdown-toggle(
-        data-toggle='dropdown',
-        data-bind='css: { disabled: !selectedCount() }'
+      .btn-group.hidden-xs.hidden-sm
+        input#glyph-size-slider.form-control.toolbar__size-slider(
+          type='range',
+          data-bind='value: fontSize, valueUpdate: "input", attr: { min: fontSizeMin, max: fontSizeMax }'
         )
-          span.caret
-      ul.dropdown-menu.pull-right
-        li: a(
-              href='#',
-              data-on-click='build_font',
-            )= self.t('download')
-
-    .btn-group.pull-right(data-bind='visible: apiMode() && apiUrl()', style='display:none')
-      //- API mode, with URL - `Export font` button
-      button.btn.btn-danger.disabled(
-        data-on-click='api.export',
-        data-bind='css: { disabled: !selectedCount() }'): strong
-        i.icon-download(data-bind='visible: !saving()')
-        i.icon-load.animate-spin(style='display:none', data-bind='visible: saving()')
-        |  
-        = self.t('export')
-        |  (
-        span#selected-glyphs-count(data-bind='text: selectedCount()') 0
-        | )
-      button.btn.btn-danger.disabled.dropdown-toggle(
-        data-toggle='dropdown',
-        data-bind='css: { disabled: !selectedCount() }'
-        )
-          span.caret
-      ul.dropdown-menu.pull-right
-        li: a(
-              href='#',
-              data-on-click='build_font',
-            )= self.t('download')
+        #glyph-size-value.toolbar__size-indicator(data-bind="text: fontSize() + 'px'")
 
 
-    .btn-group.pull-right
-      input#result-fontname.form-control._popover(type='text',
-        placeholder=self.t('file_name_placeholder'),
-        autocomplete='off',
-        pattern='[a-z0-9_\-]*',
-        data-bind='value: fontName',
-        data-content=self.t('file_name_help'),
-        data-placement='bottom',
-        data-trigger='hover',
-        data-container='.layout__fixed'
-        data-delay='{"show":500,"hide":100}')
+      .btn-group.dropdown
+
+        button.btn.btn-default.dropdown-toggle(type='button', data-toggle='dropdown')
+          i.icon-settings
+          //-span.caret
+        ul.dropdown-menu.pull-right.toolbar__settings-menu
+          li: a(
+                href='#',
+                data-on-click='import.start',
+                data-content=self.t('menu_import_help'),
+                data-placement='left',
+                data-trigger='hover',
+                data-container='.layout__fixed'
+                data-delay='{"show":500,"hide":100}'
+              )._popover= self.t('menu_import')
+          li.divider
+          li: a(href='#', data-on-click='cmd:reset_selected')= self.t('menu_unselect_all')
+          li: a(href='#', data-on-click='cmd:reset_all')= self.t('menu_reset_all')
+          li.divider
+          li
+            form.navbar-form(onsubmit='return false;')
+              .form-group
+                label(for='css-prefix')= self.t('menu_css_prefix_text')
+                input#css-prefix.form-control(type='text', data-bind='value: cssPrefixText')
+              .checkbox
+                label
+                  input(type='checkbox', data-bind='checked: cssUseSuffix')
+                  = self.t('menu_css_use_suffix')
+          li.divider
+          li: a(href='#', data-on-click='cmd:settings_dialog')= self.t('menu_advanced_settings')
 
 
-    .btn-group.dropdown.pull-right
-
-      button.btn.btn-default.dropdown-toggle(type='button', data-toggle='dropdown')
-        i.icon-settings
-        //-span.caret
-      ul.dropdown-menu.pull-right.toolbar__settings-menu
-        li: a(
-              href='#',
-              data-on-click='import.start',
-              data-content=self.t('menu_import_help'),
-              data-placement='left',
-              data-trigger='hover',
-              data-container='.layout__fixed'
-              data-delay='{"show":500,"hide":100}'
-            )._popover= self.t('menu_import')
-        li.divider
-        li: a(href='#', data-on-click='cmd:reset_selected')= self.t('menu_unselect_all')
-        li: a(href='#', data-on-click='cmd:reset_all')= self.t('menu_reset_all')
-        li.divider
-        li
-          form.navbar-form(onsubmit='return false;')
-            .form-group
-              label(for='css-prefix')= self.t('menu_css_prefix_text')
-              input#css-prefix.form-control(type='text', data-bind='value: cssPrefixText')
-            .checkbox
-              label
-                input(type='checkbox', data-bind='checked: cssUseSuffix')
-                = self.t('menu_css_use_suffix')
-        li.divider
-        li: a(href='#', data-on-click='cmd:settings_dialog')= self.t('menu_advanced_settings')
+      .btn-group
+        input#result-fontname.form-control._popover(type='text',
+          placeholder=self.t('file_name_placeholder'),
+          autocomplete='off',
+          pattern='[a-z0-9_\-]*',
+          data-bind='value: fontName',
+          data-content=self.t('file_name_help'),
+          data-placement='bottom',
+          data-trigger='hover',
+          data-container='.layout__fixed'
+          data-delay='{"show":500,"hide":100}')
 
 
-    .btn-group.hidden-xs.hidden-sm.pull-right
-      input#glyph-size-slider.form-control.toolbar__size-slider(
-        type='range',
-        data-bind='value: fontSize, valueUpdate: "input", attr: { min: fontSizeMin, max: fontSizeMax }'
-      )
-      #glyph-size-value.toolbar__size-indicator(data-bind="text: fontSize() + 'px'")
+      .btn-group(data-bind='visible: apiMode() && apiUrl()', style='display:none')
+        //- API mode, with URL - `Export font` button
+        button.btn.btn-danger.disabled(
+          data-on-click='api.export',
+          data-bind='css: { disabled: !selectedCount() }'): strong
+          i.icon-download(data-bind='visible: !saving()')
+          i.icon-load.animate-spin(style='display:none', data-bind='visible: saving()')
+          |  
+          = self.t('export')
+          |  (
+          span#selected-glyphs-count(data-bind='text: selectedCount()') 0
+          | )
+        button.btn.btn-danger.disabled.dropdown-toggle(
+          data-toggle='dropdown',
+          data-bind='css: { disabled: !selectedCount() }'
+          )
+            span.caret
+        ul.dropdown-menu.pull-right
+          li: a(
+                href='#',
+                data-on-click='build_font',
+              )= self.t('download')
+
+
+      .btn-group(data-bind='visible: apiMode() && !apiUrl()', style='display:none')
+        //- API mode, without URL - `Save session` button
+        button.btn.btn-danger.disabled(
+          data-on-click='api.update',
+          data-bind='css: {disabled: !selectedCount()}'): strong
+          i.icon-download(data-bind='visible: !saving()')
+          i.icon-load.animate-spin(style='display:none', data-bind='visible: saving()')
+          |  
+          = self.t('save')
+          |  (
+          span#selected-glyphs-count(data-bind='text: selectedCount()') 0
+          | )
+        button.btn.btn-danger.disabled.dropdown-toggle(
+          data-toggle='dropdown',
+          data-bind='css: { disabled: !selectedCount() }'
+          )
+            span.caret
+        ul.dropdown-menu.pull-right
+          li: a(
+                href='#',
+                data-on-click='build_font',
+              )= self.t('download')
+
+
+      //- Show button, depending on mode
+      .btn-group(data-bind='visible: !apiMode()')
+        //- Standard mode - `Download` button
+        button.btn.btn-danger.disabled(
+          data-on-click='build_font',
+          data-bind='css: {disabled: !selectedCount()}'): strong
+          i.icon-download(data-bind='visible: !building()')
+          i.icon-load.animate-spin(style='display:none', data-bind='visible: building()')
+          |  
+          = self.t('download')
+          |  (
+          span#selected-glyphs-count(data-bind='text: selectedCount()') 0
+          | )

--- a/client/models/models.js
+++ b/client/models/models.js
@@ -98,6 +98,14 @@ N.wire.once('navigate.done', { priority: -100 }, function () {
     // Helpers
     //
 
+    this.selectOnEnter = function (glyph, event) {
+      if ((event.keyCode || event.which) === 13) {
+        self.selected(!self.selected());
+      }
+      
+      return true;
+    };
+
     this.remove = function () {
       self.font.removeGlyph(self.uid);
     };


### PR DESCRIPTION
My organization began using Fontello last week. We have a company policy that all internal sites we maintain must be accessible. Before our dev team was able to utilize our internal build of Fontello, we need to fix some keyboard accessibility issues the site exhibits. This pull-request shares the work we did. Feel free to merge it.

- User should be able to tab through each control in the toolbar, in the correct order.
- User should be able to tab through each glyph in a fontset, and toggle a glyph selection by pressing "enter"