### PR TITLE
produce polymer/fontname-iconset-svg.html font

### DIFF
--- a/internal/fontello/font_build/_lib/worker.js
+++ b/internal/fontello/font_build/_lib/worker.js
@@ -25,7 +25,8 @@ const JSZip     = require('jszip');
 const TEMPLATES_DIR = path.join(__dirname, '../../../../support/font-templates');
 const TEMPLATES = {};
 const SVG_FONT_TEMPLATE = _.template(fs.readFileSync(path.join(TEMPLATES_DIR, 'font/svg.tpl'), 'utf8'));
-const POLYMER_FONT_TEMPLATE = _.template(fs.readFileSync(path.join(TEMPLATES_DIR, 'font/iron_iconset_svg.tpl'), 'utf8'));
+const POLYMER_FONT_TEMPLATE = _.template(fs.readFileSync(path.join(TEMPLATES_DIR,
+                                         'font/iron_iconset_svg.tpl'), 'utf8'));
 
 
 _.forEach({
@@ -72,10 +73,10 @@ function buildPolymerConfig(originalBuilderConfig) {
   let fontHeight = fontAscent - polymerBuilderConfig.font.descent;
   for (let i = 0; i < polymerBuilderConfig.glyphs.length; i++) {
     let glyph = polymerBuilderConfig.glyphs[i];
-    let xScale = Math.min(1,fontHeight/glyph.width);
-    let yScale = -1 * Math.min(1,fontHeight/glyph.width);
-    let xTranslate = Math.max(0,(fontHeight-glyph.width)/2);
-    let yTranslate = -1 * fontAscent * (2 - Math.min(1,fontHeight/glyph.width));
+    let xScale = Math.min(1, fontHeight / glyph.width);
+    let yScale = -1 * Math.min(1, fontHeight / glyph.width);
+    let xTranslate = Math.max(0, (fontHeight - glyph.width) / 2);
+    let yTranslate = -1 * fontAscent * (2 - Math.min(1, fontHeight / glyph.width));
     polymerBuilderConfig.glyphs[i].d = new SvgPath(glyph.d)
         .translate(xTranslate, yTranslate)
         .scale(xScale, yScale)

--- a/support/font-templates/README.txt
+++ b/support/font-templates/README.txt
@@ -25,6 +25,8 @@ Comments on archive content
   twitter bootstrap. Also, you can skip <i> style and assign icon classes
   directly to text elements, if you don't mind about IE7.
 
+- /polymer/*-iconset-svg.html - font in Polymer iron-iconset-svg format
+
 - demo.html - demo file, to show your webfont content
 
 - LICENSE.txt - license info about source fonts, used to build your one.

--- a/support/font-templates/font/iron_iconset_svg.tpl
+++ b/support/font-templates/font/iron_iconset_svg.tpl
@@ -1,0 +1,20 @@
+<!--
+${font.copyright}
+
+Usage:
+<link rel="import" href="/path/to/${font.fontname}-iconset-svg.html">
+<iron-icon icon="${font.fontname}:ICON_NAME"></iron-icon>
+
+-->
+<link rel="import" href="../bower_components/iron-icon/iron-icon.html">
+<link rel="import" href="../bower_components/iron-iconset-svg/iron-iconset-svg.html">
+
+<iron-iconset-svg size="${font.ascent - font.descent}" name="${font.fontname}">
+<svg xmlns="http://www.w3.org/2000/svg">
+<defs>
+<% glyphs.forEach(function(glyph) { %>
+<g id="${glyph.css}"><path d="${glyph.d}"/></g>
+<% }); %>
+</defs>
+</svg>
+</iron-iconset-svg>


### PR DESCRIPTION
These changes add a ```polymer/[font-name]-iconset-svg.html``` to the font package.  This is a basic iron-iconset-svg containing all the selected glyphs.

If you don't think it belongs here, or if it would be better as a separate option, let me know.

I used these modifications to produce the polymer [webfonts-iconset-svg](https://github.com/ilikerobots/webfonts-iconset-svg)

And btw, a big thank you for making fontello in the first place.