### PR TITLE
Fix typo on the default directory os module method name.

### DIFF
--- a/internal/fontello/font_build/font_build.js
+++ b/internal/fontello/font_build/font_build.js
@@ -71,7 +71,7 @@ module.exports = function (N, apiPath) {
       clientConfig: data.config,
       builderConfig,
       cwdDir: N.mainApp.root,
-      tmpDir: path.join(os.tmpDir(), 'fontello', `fontello-${data.fontId.substr(0, 8)}`),
+      tmpDir: path.join(os.tmpdir(), 'fontello', `fontello-${data.fontId.substr(0, 8)}`),
       timestamp: Date.now(),
       result: null,
       logger


### PR DESCRIPTION
It seems that according to the [node documentation](https://nodejs.org/api/os.html#os_os_tmpdir) the method should be named `tmpdir`. Otherwise I'm getting an error when running the server locally:
```

TypeError: os.tmpDir is not a function
    at build_font (/home/user/fontello/internal/fontello/font_build/font_build.js:74:28)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
From previous event:
    at runHandler (/home/user/fontello/node_modules/event-wire/index.js:274:28)
    at /home/user/fontello/node_modules/event-wire/index.js:325:32
From previous event:
    at /home/user/fontello/node_modules/event-wire/index.js:324:13
    at Array.forEach (<anonymous>)
    at Wire.__emit (/home/user/fontello/node_modules/event-wire/index.js:319:12)
    at Wire.__emit_with_check (/home/user/fontello/node_modules/event-wire/index.js:369:15)
    at Wire.emit (/home/user/fontello/node_modules/event-wire/index.js:389:30)
    at Server.<anonymous> (/home/user/fontello/lib/autoload/hooks/init/service_www.js:317:14)
    at Server.emit (events.js:314:20)
    at parserOnIncoming (_http_server.js:777:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:119:17)
```
when generating a font. Once I fix this typo and install `ttfautohint` the server shows no errors. I'm using Ubuntu 20.04.