### PR TITLE
Add SVG symbol file generation

### DIFF
--- a/internal/fontello/font_build/_lib/config.js
+++ b/internal/fontello/font_build/_lib/config.js
@@ -82,6 +82,7 @@ function collectGlyphsInfo(clientConfig) {
         code:     glyph.code,
         css:      glyph.css,
         width:    +(glyph.svg.width * scale).toFixed(1),
+        height:   +(1000 * scale).toFixed(1),
         d:        sp.toString(),
         segments: sp.segments.length
       });
@@ -106,6 +107,7 @@ function collectGlyphsInfo(clientConfig) {
       css:       glyph.css || glyphEmbedded.css,
       'css-ext': glyphEmbedded['css-ext'],
       width:     +(glyphEmbedded.svg.width * scale).toFixed(1),
+      height:    +(1000 * scale).toFixed(1),
       d:         sp.toString(),
       segments:  sp.segments.length
     });
@@ -184,7 +186,8 @@ module.exports = function fontConfig(clientConfig) {
       copyright: !_.isEmpty(fontsInfo) ? defaultCopyright : (clientConfig.copyright || defaultCopyright),
       ascent:    clientConfig.ascent,
       descent:   clientConfig.ascent - clientConfig.units_per_em,
-      weight:    400
+      weight:    400,
+      height:    400
     },
     hinting: clientConfig.hinting !== false,
     meta: {

--- a/internal/fontello/font_build/_lib/worker.js
+++ b/internal/fontello/font_build/_lib/worker.js
@@ -28,6 +28,7 @@ const execFile  = promisify(require('child_process').execFile);
 const TEMPLATES_DIR = path.join(__dirname, '../../../../support/font-templates');
 const TEMPLATES = {};
 const SVG_FONT_TEMPLATE = ejs.compile(fs.readFileSync(path.join(TEMPLATES_DIR, 'font/svg.ejs'), 'utf8'));
+const SVG_SYMBOL_TEMPLATE = ejs.compile(fs.readFileSync(path.join(TEMPLATES_DIR, 'images/svg.ejs'), 'utf8'));
 
 
 _.forEach({
@@ -84,6 +85,7 @@ async function generateFont(taskInfo) {
   files = {
     config:      path.join(taskInfo.tmpDir, 'config.json'),
     svg:         path.join(taskInfo.tmpDir, 'font', `${fontname}.svg`),
+    svgSymbols:  path.join(taskInfo.tmpDir, 'images', `${fontname}.svg`),
     ttf:         path.join(taskInfo.tmpDir, 'font', `${fontname}.ttf`),
     ttfUnhinted: path.join(taskInfo.tmpDir, 'font', `${fontname}-unhinted.ttf`),
     eot:         path.join(taskInfo.tmpDir, 'font', `${fontname}.eot`),
@@ -96,13 +98,14 @@ async function generateFont(taskInfo) {
   //
   /*eslint-disable new-cap*/
   let svgOutput = SVG_FONT_TEMPLATE(taskInfo.builderConfig);
-
+  let svgSymbolOutput = SVG_SYMBOL_TEMPLATE(taskInfo.builderConfig);
 
   // Prepare temporary working directory.
   //
   await rimraf(taskInfo.tmpDir);
   await mkdirp(taskInfo.tmpDir);
   await mkdirp(path.join(taskInfo.tmpDir, 'font'));
+  await mkdirp(path.join(taskInfo.tmpDir, 'images'));
   await mkdirp(path.join(taskInfo.tmpDir, 'css'));
 
 
@@ -112,6 +115,7 @@ async function generateFont(taskInfo) {
 
   await write(files.config, configOutput, 'utf8');
   await write(files.svg, svgOutput, 'utf8');
+  await write(files.svgSymbols, svgSymbolOutput, 'utf8');
 
 
   // Convert SVG to TTF

--- a/support/font-templates/images/svg.ejs
+++ b/support/font-templates/images/svg.ejs
@@ -1,0 +1,10 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" display="none">
+<metadata><%= font.copyright %></metadata>
+<% glyphs.forEach(function(glyph) { %>
+<symbol id="<%= meta.css_prefix_text %><%= glyph.css %>" viewBox="0 0 <%= glyph.width %> <%= glyph.height %>">
+  <path d="<%= glyph.d %>" />
+</symbol>
+<% }); %>
+</svg>


### PR DESCRIPTION
Add generation of SVG symbol file (SVG Sprite) that can be used to include icons as images. Similar to the Fontastic.me SVG Sprite output.

```html
<svg xmlns="http://www.w3.org/2000/svg" display="none"><metadata>Copyright (C) 2022 by original authors @ fontello.com</metadata><symbol id="icon-plus" viewBox="0 0 714.3 1000">...</symbol></svg>
...
<svg class="icon-plus" style="height: 1em; width: 1em">
  <use xlink:href="#icon-plus"></use>
</svg>
```